### PR TITLE
chore(package.json): Bump the version of hexo-theme-doc to 1.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "hexo-renderer-marked": "^0.2.10",
     "hexo-renderer-sass": "^0.3.2",
     "hexo-server": "^0.2.1",
-    "hexo-theme-doc": "^0.1.0"
+    "hexo-theme-doc": "^1.0.0-rc.1"
   }
 }


### PR DESCRIPTION
Bump the version of `hexo-theme-doc` to its latest version.

Related to https://github.com/zalando-incubator/hexo-theme-doc-seed/issues/6